### PR TITLE
Add HLS m3u8 format to TuneIn OPML querry

### DIFF
--- a/Slim/Plugin/InternetRadio/TuneIn.pm
+++ b/Slim/Plugin/InternetRadio/TuneIn.pm
@@ -168,6 +168,8 @@ sub fixUrl {
 		wmpro   => 'wmap',
 		wma     => 'wma',
 		wmvoice => 'wma',
+		# Apple HLS m3u8 is supported through the PlayHLS plugin and ffmpeg
+		hls     => 'hls',
 		# Real Player is supported through the AlienBBC plugin
 		real    => 'rtsp',
 	);


### PR DESCRIPTION
This add support to Internet Radio browser (TuneIn) for radio station using HLS format.
HLS will be used after the other audio formats
Requires bpa's PlayHLS plugin with ffmpeg
Tested on Ubuntu 14.04 + ffmpeg + LMS previous nightly built
